### PR TITLE
Add rule VerbingNouns.yml

### DIFF
--- a/Openly/VerbingNouns.yml
+++ b/Openly/VerbingNouns.yml
@@ -1,0 +1,7 @@
+# Checks for sentences where e.g. "perform validation" can be simplified to "validate".
+extends: existence
+ignorecase: true
+message: "Simplify '%s' by removing the first word and making the last word a verb."
+level: suggestion
+tokens:
+  - (?:(perform|performs|do|does|run|runs)( \w+){0,2} \w+(tions?|ing))


### PR DESCRIPTION
Checks for sentences where e.g. "perform validation" can be simplified to "validate".

(As requested on Write the Docs Slack: https://writethedocs.slack.com/archives/CBWQQ5E57/p1632413363047400)